### PR TITLE
refactor(auth): replace `ENABLE_HTTPS` checks with `BASE_URL` scheme …

### DIFF
--- a/pve-compose.yml
+++ b/pve-compose.yml
@@ -22,6 +22,8 @@ containers:
     purge_on_upgrade: false
     environment:
       ENV: "production"
+      COOKIE_SECRET: "changeme"
+      BASE_URL: "http://auth-server.myc"
       # PORT: "8080"
       # DATABASE_TYPE: "postgres"
       # DATABASE_HOST: "db"

--- a/srv/src/auth/flow-id-cookie.service.ts
+++ b/srv/src/auth/flow-id-cookie.service.ts
@@ -10,7 +10,7 @@
  * state-changing POST in that flow, without requiring any DB storage.
  *
  * Cookie options mirror `sid` (same path `/api/oauth`, same SameSite,
- * same HttpOnly, same signed, same `secure` gating on `ENABLE_HTTPS`).
+ * same HttpOnly, same signed, same `secure` gating on `BASE_URL` scheme).
  *
  * Requirements: 5.10, 5.11, 5.14, 12.6
  */
@@ -69,9 +69,7 @@ export class FlowIdCookieService {
         return {
             signed: true,
             httpOnly: true,
-            secure: this.env.get("ENABLE_HTTPS") === "true"
-                || this.env.get("ENABLE_HTTPS") === true
-                || process.env.NODE_ENV === "production",
+            secure: String(this.env.get("BASE_URL", "")).startsWith("https"),
             sameSite: "lax" as const,
             path: FlowIdCookieService.COOKIE_PATH,
             maxAge: maxAgeMs,

--- a/srv/src/controllers/oauth-token.controller.ts
+++ b/srv/src/controllers/oauth-token.controller.ts
@@ -412,7 +412,7 @@ export class OAuthTokenController {
         return {
             signed: true,
             httpOnly: true,
-            secure: Environment.get('ENABLE_HTTPS') === 'true' || process.env.NODE_ENV === 'production',
+            secure: String(Environment.get('BASE_URL', '')).startsWith('https'),
             sameSite: 'lax' as const,
             path: '/api/oauth',
             maxAge: maxAge * 1000, // convert seconds to ms

--- a/srv/src/controllers/revocation.controller.ts
+++ b/srv/src/controllers/revocation.controller.ts
@@ -130,7 +130,7 @@ export class RevocationController {
         res.cookie('sid', '', {
             signed: true,
             httpOnly: true,
-            secure: Environment.get('ENABLE_HTTPS') === 'true' || process.env.NODE_ENV === 'production',
+            secure: String(Environment.get('BASE_URL', '')).startsWith('https'),
             sameSite: 'lax' as const,
             path: '/api/oauth',
             maxAge: 0,


### PR DESCRIPTION
…validation for cookie security flags

- Updated OAuth token, revocation controllers, and FlowIdCookieService to determine the `secure` flag based on whether `BASE_URL` starts with `https`.
- Updated `pve-compose.yml` to include `BASE_URL` and `COOKIE_SECRET` environment variables.